### PR TITLE
use https as curl to http fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
     apt-get install --no-install-recommends -y \
     curl unzip default-jre && \
     #curl -sSJ -O http://neuroimage.usc.edu/bst/getupdate.php?d=bst_bin_R2021a_${APP_VERSION}.zip && \
-    curl -sSJ -O "http://neuroimage.usc.edu/bst/getupdate.php?c=UbsM09&src=0&bin=1" && \
+    curl -sSJ -O "https://neuroimage.usc.edu/bst/getupdate.php?c=UbsM09&src=0&bin=1" && \
     #curl -sSJ -O http://neuroimage.usc.edu/bst/getupdate.php?c=UbsM09 && \
     mkdir ./install && \
     #unzip -q -d ./install bst_bin_R2021a_${APP_VERSION}.zip && \


### PR DESCRIPTION
the following pipeline failed on curl
40.02 curl: (56) Recv failure: Connection reset by peer
https://gitlab.hbp.link/hip/app-in-browser/-/jobs/3329

trying locally, using https seems to resolve the issue